### PR TITLE
Support Bracket Highlight and Change the PHP tags to purple

### DIFF
--- a/themes/vim-dark-hard.json
+++ b/themes/vim-dark-hard.json
@@ -3,6 +3,16 @@
   "type": "dark",
   "tokenColors": [
     {
+      "name": "Change the PHP tags to purple (subjective suggestion)",
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#d3869b"
+			}
+		},
+    {
       "settings": {
         "background": "#1d2021",
         "foreground": "#ebdbb2"
@@ -996,6 +1006,12 @@
     "statusBar.noFolderBorder": "#1d202100",
     "statusBar.prominentBackground": "#689d6a",
     "statusBar.prominentHoverBackground": "#689d6a70",
+    "editorBracketHighlight.foreground1": "#ebdbb2",
+    "editorBracketHighlight.foreground2": "#689d6a",
+    "editorBracketHighlight.foreground3": "#458588",
+    "editorBracketHighlight.foreground4": "#b16286",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#fabd2f",
     "terminal.ansiBlack": "#3c3836",
     "terminal.ansiBrightBlack": "#928374",
     "terminal.ansiRed": "#cc241d",

--- a/themes/vim-dark-medium.json
+++ b/themes/vim-dark-medium.json
@@ -3,6 +3,16 @@
   "type": "dark",
   "tokenColors": [
     {
+      "name": "Change the PHP tags to purple (subjective suggestion)",
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#d3869b"
+			}
+		},
+    {
       "settings": {
         "background": "#282828",
         "foreground": "#ebdbb2"
@@ -996,6 +1006,12 @@
     "statusBar.noFolderBorder": "#28282800",
     "statusBar.prominentBackground": "#689d6a",
     "statusBar.prominentHoverBackground": "#689d6a70",
+    "editorBracketHighlight.foreground1": "#ebdbb2",
+    "editorBracketHighlight.foreground2": "#8ec07c",
+    "editorBracketHighlight.foreground3": "#458588",
+    "editorBracketHighlight.foreground4": "#b16286",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#fabd2f",
     "terminal.ansiBlack": "#3c3836",
     "terminal.ansiBrightBlack": "#928374",
     "terminal.ansiRed": "#cc241d",

--- a/themes/vim-dark-soft.json
+++ b/themes/vim-dark-soft.json
@@ -3,6 +3,16 @@
   "type": "dark",
   "tokenColors": [
     {
+      "name": "Change the PHP tags to purple (subjective suggestion)",
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#d3869b"
+			}
+		},
+    {
       "settings": {
         "background": "#32302f",
         "foreground": "#ebdbb2"
@@ -996,6 +1006,12 @@
     "statusBar.noFolderBorder": "#32302f00",
     "statusBar.prominentBackground": "#689d6a",
     "statusBar.prominentHoverBackground": "#689d6a70",
+    "editorBracketHighlight.foreground1": "#ebdbb2",
+    "editorBracketHighlight.foreground2": "#8ec07c",
+    "editorBracketHighlight.foreground3": "#458588",
+    "editorBracketHighlight.foreground4": "#b16286",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#fabd2f",
     "terminal.ansiBlack": "#3c3836",
     "terminal.ansiBrightBlack": "#928374",
     "terminal.ansiRed": "#cc241d",

--- a/themes/vim-light-hard.json
+++ b/themes/vim-light-hard.json
@@ -2,6 +2,16 @@
   "name": "Vim Light Hard",
   "tokenColors": [
     {
+      "name": "Change the PHP tags to purple (subjective suggestion)",
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#8f3f71"
+			}
+		},
+    {
       "settings": {
         "background": "#f9f5d7",
         "foreground": "#3c3836"
@@ -995,6 +1005,12 @@
     "statusBar.noFolderBorder": "#f9f5d700",
     "statusBar.prominentBackground": "#689d6a",
     "statusBar.prominentHoverBackground": "#689d6a70",
+    "editorBracketHighlight.foreground1": "#7c6f64",
+    "editorBracketHighlight.foreground2": "#689d6a",
+    "editorBracketHighlight.foreground3": "#458588",
+    "editorBracketHighlight.foreground4": "#b16286",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#b57614",
     "terminal.ansiBlack": "#ebdbb2",
     "terminal.ansiBrightBlack": "#928374",
     "terminal.ansiRed": "#cc241d",

--- a/themes/vim-light-medium.json
+++ b/themes/vim-light-medium.json
@@ -2,6 +2,16 @@
   "name": "Vim Light Medium",
   "tokenColors": [
     {
+      "name": "Change the PHP tags to purple (subjective suggestion)",
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#8f3f71"
+			}
+		},
+    {
       "settings": {
         "background": "#fbf1c7",
         "foreground": "#3c3836"
@@ -995,6 +1005,13 @@
     "statusBar.noFolderBorder": "#fbf1c700",
     "statusBar.prominentBackground": "#689d6a",
     "statusBar.prominentHoverBackground": "#689d6a70",
+    
+    "editorBracketHighlight.foreground1": "#7c6f64",
+    "editorBracketHighlight.foreground2": "#689d6a",
+    "editorBracketHighlight.foreground3": "#458588",
+    "editorBracketHighlight.foreground4": "#b16286",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#b57614",
     "terminal.ansiBlack": "#ebdbb2",
     "terminal.ansiBrightBlack": "#928374",
     "terminal.ansiRed": "#cc241d",

--- a/themes/vim-light-soft.json
+++ b/themes/vim-light-soft.json
@@ -2,6 +2,16 @@
   "name": "Vim Light Soft",
   "tokenColors": [
     {
+      "name": "Change the PHP tags to purple (subjective suggestion)",
+			"scope": [
+				"punctuation.section.embedded.begin.php",
+				"punctuation.section.embedded.end.php"
+			],
+			"settings": {
+				"foreground": "#8f3f71"
+			}
+		},
+    {
       "settings": {
         "background": "#f2e5bc",
         "foreground": "#3c3836"
@@ -995,6 +1005,13 @@
     "statusBar.noFolderBorder": "#f2e5bc00",
     "statusBar.prominentBackground": "#689d6a",
     "statusBar.prominentHoverBackground": "#689d6a70",
+    
+    "editorBracketHighlight.foreground1": "#7c6f64",
+    "editorBracketHighlight.foreground2": "#689d6a",
+    "editorBracketHighlight.foreground3": "#458588",
+    "editorBracketHighlight.foreground4": "#b16286",
+    "editorBracketHighlight.foreground5": "#d79921",
+    "editorBracketHighlight.foreground6": "#b57614",
     "terminal.ansiBlack": "#ebdbb2",
     "terminal.ansiBrightBlack": "#928374",
     "terminal.ansiRed": "#cc241d",


### PR DESCRIPTION
for both color variations.

### Support Bracket Highlight

Beautiful and makes the nesting hierarchy clearer.

![Bracket Highlight Example](https://user-images.githubusercontent.com/39868412/222065594-f38d3e69-85cc-47c5-89bb-d0c80dafec3f.png)

### Change the PHP tags to purple

The current version of the theme does not color PHP tags, I changed it to purple; *this is a subjective suggestion, you can choose to decline.*

![PHP tags Example](https://user-images.githubusercontent.com/39868412/222065061-f864a8ea-cd7d-432a-9496-f42988498de6.png)
